### PR TITLE
feat: refactor inbox member retrieval to exclude administrators

### DIFF
--- a/app/controllers/api/v1/widget/inbox_members_controller.rb
+++ b/app/controllers/api/v1/widget/inbox_members_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::Widget::InboxMembersController < Api::V1::Widget::BaseController
   skip_before_action :set_contact
 
   def index
-    @inbox_members = @web_widget.inbox.inbox_members.includes(:user)
+    @inbox_members = @web_widget.inbox.inbox_members.non_administrators.includes(:user)
   end
 end

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -34,6 +34,8 @@ class AccountUser < ApplicationRecord
 
   accepts_nested_attributes_for :account
 
+  scope :non_administrators, -> { where.not(role: :administrator) }
+
   after_create_commit :notify_creation, :create_notification_setting
   after_destroy :notify_deletion, :remove_user_from_account
   after_save :update_presence_in_redis, if: :saved_change_to_availability?

--- a/app/models/inbox_member.rb
+++ b/app/models/inbox_member.rb
@@ -25,6 +25,8 @@ class InboxMember < ApplicationRecord
   after_create :add_agent_to_round_robin
   after_destroy :remove_agent_from_round_robin
 
+  scope :non_administrators, -> { where.not(user_id: AccountUser.non_administrators.pluck(:id)) }
+
   private
 
   def add_agent_to_round_robin

--- a/lib/online_status_tracker.rb
+++ b/lib/online_status_tracker.rb
@@ -64,8 +64,10 @@ class OnlineStatusTracker
     account = Account.find(account_id)
     range_start = (Time.zone.now - PRESENCE_DURATION).to_i
     user_ids = ::Redis::Alfred.zrangebyscore(presence_key(account_id, 'User'), range_start, '+inf')
-    # since we are dealing with redis items as string, casting to string
-    user_ids += account.account_users.where(auto_offline: false)&.map(&:user_id)&.map(&:to_s)
-    user_ids.uniq
+
+    # TODO: oportunidade de melhoria
+    without_admin_ids = account.account_users.where(user_id: user_ids.map(&:to_i)).non_administrators
+    without_admin_ids += account.account_users.non_administrators.where(auto_offline: false)&.map(&:user_id)&.map(&:to_s)
+    without_admin_ids.uniq
   end
 end


### PR DESCRIPTION
This pull request introduces a new scope to exclude administrators from certain queries and applies this scope across various parts of the codebase. The most important changes include adding the `non_administrators` scope to the `AccountUser` and `InboxMember` models, updating the `InboxMembersController` to use this scope, and modifying the `get_available_user_ids` method to exclude administrators.

### Scope Addition:

* [`app/models/account_user.rb`](diffhunk://#diff-382024ec418cd65f82ba1fa6cddff39e1850d37f68269ec8ff2b172772e74046R37-R38): Added `non_administrators` scope to filter out administrators.
* [`app/models/inbox_member.rb`](diffhunk://#diff-63c01c80d89a7cb125296c4ba3fe5abff20a25ab945bf59a585c2013cd0c48faR28-R29): Added `non_administrators` scope to filter out administrators based on `AccountUser` scope.

### Controller Update:

* [`app/controllers/api/v1/widget/inbox_members_controller.rb`](diffhunk://#diff-a519d8b77aad2d96527841bef497b9ae301b17c06f9e3ac0d2d85a44667f4dceL5-R5): Updated the `index` action to use the `non_administrators` scope.

### Method Update:

* [`lib/online_status_tracker.rb`](diffhunk://#diff-20730324f5242e3bf6916b8a7dbe5ff58aa1543b619a5d5bd3c749136515b401L67-R71): Modified the `get_available_user_ids` method to exclude administrators from the returned user IDs.