### PR TITLE
feat: add chat list agent

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -98,7 +98,7 @@
     />
 
     <chat-type-tabs
-      v-if="!hasAppliedFiltersOrActiveFolders"
+      v-if="!hasAppliedFiltersOrActiveFolders && currentUser.role !== 'agent'"
       :items="assigneeTabItems"
       :active-tab="activeAssigneeTab"
       class="tab--chat-type"


### PR DESCRIPTION
This pull request includes a small but important change to the `ChatList.vue` component. The change ensures that the chat type tabs are only displayed if the user does not have applied filters or active folders and if the current user's role is not 'agent'.

* [`app/javascript/dashboard/components/ChatList.vue`](diffhunk://#diff-b5614c5cdc9eeb65a0625d2beb23bff694ad04410a416352ce3c3c3ea2972af4L101-R101): Modified the condition to display chat type tabs by adding a check for the user's role, ensuring that users with the role 'agent' do not see the tabs.