### PR TITLE
feat: implement user-specific conversation assignment and limit per a…

### DIFF
--- a/app/helpers/api/v1/conversations_helper.rb
+++ b/app/helpers/api/v1/conversations_helper.rb
@@ -7,7 +7,11 @@ module Api::V1::ConversationsHelper
     return { error: 'no open conversations' } if open_inbox.blank?
 
     open_inbox.each do |inbox, conversations|
-      assign_conversations_to_agent(inbox, conversations, current_user)
+      # check if has specific users to assign
+      assign_conversations_to_users(inbox, conversations, current_user) if inbox.auto_assignment_only_this_agents_ids.present?
+
+      max_limit = inbox.auto_assignment_config['max_assignment_limit_team_per_person'].to_i
+      assign_conversations_to_agent(inbox, conversations, current_user, max_limit) if max_limit.positive?
     end
 
     true
@@ -16,8 +20,7 @@ module Api::V1::ConversationsHelper
     { error: e.message }
   end
 
-  def self.assign_conversations_to_agent(inbox, conversations, current_user)
-    max_limit = inbox.auto_assignment_config['max_assignment_limit'].to_i
+  def self.assign_conversations_to_agent(inbox, conversations, current_user, max_limit)
     user_assigned_count = inbox.conversations.where(assignee_id: current_user.id).count
 
     conversations.each do |conversation|
@@ -27,6 +30,22 @@ module Api::V1::ConversationsHelper
       conversation.assignee_id = current_user.id
 
       user_assigned_count += 1 if conversation.save!
+    end
+  end
+
+  def self.assign_conversations_to_users(inbox, conversations, _current_user)
+    user_ids = inbox.auto_assignment_only_this_agents_ids
+    return if user_ids.blank?
+
+    user_index = 0
+    conversations.each do |conversation|
+      user_id = user_ids[user_index]
+      Rails.logger.info "Assigning conversation #{conversation.id} to agent #{user_id}"
+      conversation.assignee_id = user_id
+
+      if conversation.save!
+        user_index = (user_index + 1) % user_ids.size # Avança para o próximo usuário de forma cíclica
+      end
     end
   end
 end

--- a/enterprise/app/models/enterprise/inbox.rb
+++ b/enterprise/app/models/enterprise/inbox.rb
@@ -31,6 +31,10 @@ module Enterprise::Inbox
     account.feature_enabled?('response_bot') && response_sources.any?
   end
 
+  def auto_assignment_only_this_agents_ids
+    @auto_assignment_only_this_agents_ids ||= auto_assignment_config['only_this_agents'].presence || []
+  end
+
   private
 
   def get_agent_ids_over_assignment_limit(limit, ids = nil)
@@ -54,10 +58,6 @@ module Enterprise::Inbox
 
   def max_assignment_limit_per_team
     auto_assignment_config['max_assignment_limit_per_team'].presence || Team.max_assignment_limit
-  end
-
-  def auto_assignment_only_this_agents_ids
-    @auto_assignment_only_this_agents_ids ||= auto_assignment_config['only_this_agents'].presence || []
   end
 
   def max_assignment_limit_team_per_person


### PR DESCRIPTION
This pull request introduces enhancements to the conversation assignment logic in the `app/helpers/api/v1/conversations_helper.rb` file and modifies the `enterprise/app/models/enterprise/inbox.rb` file to support the new assignment configurations. The most important changes include adding a method for assigning conversations to specific users, updating the existing method to respect a maximum assignment limit, and refactoring the `Inbox` model to expose new configuration options.

Enhancements to conversation assignment logic:

* [`app/helpers/api/v1/conversations_helper.rb`](diffhunk://#diff-163bef7264cbe7b7e64fd416b473a30304b2d322cc9f5165e2048f4ed41bca8dR35-R50): Added the `assign_conversations_to_users` method to assign conversations to specific users based on the `auto_assignment_only_this_agents_ids` configuration.
* [`app/helpers/api/v1/conversations_helper.rb`](diffhunk://#diff-163bef7264cbe7b7e64fd416b473a30304b2d322cc9f5165e2048f4ed41bca8dL10-R14): Updated the `assign_conversations_to_agent` method to accept a `max_limit` parameter and modified the `assign_open_conversations` method to utilize this limit. [[1]](diffhunk://#diff-163bef7264cbe7b7e64fd416b473a30304b2d322cc9f5165e2048f4ed41bca8dL10-R14) [[2]](diffhunk://#diff-163bef7264cbe7b7e64fd416b473a30304b2d322cc9f5165e2048f4ed41bca8dL19-R23)

Refactoring and new configuration options in the `Inbox` model:

* [`enterprise/app/models/enterprise/inbox.rb`](diffhunk://#diff-4a6a54ed4a8b6adba659c167039938136e11fe4ded6495c2a35c3ff0551b2f09R34-R37): Added the `auto_assignment_only_this_agents_ids` method to return the list of specific agents for auto-assignment.
* [`enterprise/app/models/enterprise/inbox.rb`](diffhunk://#diff-4a6a54ed4a8b6adba659c167039938136e11fe4ded6495c2a35c3ff0551b2f09L59-L62): Removed the redundant `auto_assignment_only_this_agents_ids` method from the private section as it is now a public method.