### PR TITLE
MAIS-250 - Fix Bug Agent can see Conversations from another Team

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -39,6 +39,21 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def filter
+    if current_user.agent? && params[:payload].none? { |filter| filter['attribute_key'] == 'team_id' }
+      if params[:payload].present?
+        params[:payload].last['query_operator'] = 'and'
+      end
+
+      team_id = current_user.team_ids.first
+      params[:payload] << {
+        'attribute_key' => 'team_id',
+        'filter_operator' => 'equal_to',
+        'values' => [team_id],
+        'attribute_model' => 'standard',
+        'custom_attribute_type' => ''
+      }
+    end
+    
     result = ::Conversations::FilterService.new(params.permit!, current_user).perform
     @conversations = result[:conversations]
     @conversations_count = result[:count]

--- a/app/helpers/api/v1/conversations_helper.rb
+++ b/app/helpers/api/v1/conversations_helper.rb
@@ -10,7 +10,7 @@ module Api::V1::ConversationsHelper
 
     true
   rescue StandardError => e
-    Rails.logger.error e.message
+    Rails.logger.error e.message, e.backtrace
     { error: e.message }
   end
 

--- a/app/helpers/api/v1/conversations_helper.rb
+++ b/app/helpers/api/v1/conversations_helper.rb
@@ -2,15 +2,15 @@ module Api::V1::ConversationsHelper
   def self.assign_open_conversations(current_user, current_account)
     open_inbox = fetch_open_inboxes(current_account)
 
-    return { error: 'no open conversations' } if open_inbox.count.zero?
+    return { error: 'no open conversations' } if open_inbox.empty?
 
-    open_inbox do |inbox, conversations|
+    open_inbox.each do |inbox, conversations|
       assign_conversations(inbox, conversations, current_user)
     end
 
     true
   rescue StandardError => e
-    Rails.logger.error e.message, e.backtrace
+    Rails.logger.error(e.message, e.backtrace)
     { error: e.message }
   end
 
@@ -23,7 +23,7 @@ module Api::V1::ConversationsHelper
   end
 
   def self.assign_conversations(inbox, conversations, current_user)
-    Rails.logger.info 'assign_conversations', inbox.id, conversations.count
+    Rails.logger.info "assign_conversations - inbox_id: #{inbox.id}, conversations_count: #{conversations.count}"
     max_limit = inbox.max_assignment_limit_team_per_person.to_i
     user_ids = inbox.auto_assignment_only_this_agents_ids
 

--- a/app/helpers/api/v1/conversations_helper.rb
+++ b/app/helpers/api/v1/conversations_helper.rb
@@ -10,7 +10,7 @@ module Api::V1::ConversationsHelper
 
     true
   rescue StandardError => e
-    Rails.logger.error(e.message, e.backtrace)
+    Rails.logger.error("Error: #{e.message}\nBacktrace: #{e.backtrace.join("\n")}")
     { error: e.message }
   end
 

--- a/app/helpers/api/v1/conversations_helper.rb
+++ b/app/helpers/api/v1/conversations_helper.rb
@@ -5,6 +5,8 @@ module Api::V1::ConversationsHelper
     return { error: 'no open conversations' } if open_inbox.empty?
 
     open_inbox.each do |inbox, conversations|
+      next if inbox.nil?
+
       assign_conversations(inbox, conversations, current_user)
     end
 


### PR DESCRIPTION
This pull request adds a filter for team_id when agents are filtering conversations.

Improvements to conversation filtering and handling:

* [`app/controllers/api/v1/accounts/conversations_controller.rb`](diffhunk://#diff-8fb41fe61719f585df82857783e71659e44f32cbec1d4e71acd3c95323d7833eR42-R56): Added a filter for `team_id` when the current user is an agent and no such filter is present in the payload. This ensures that agents only see conversations relevant to their team.
