### PR TITLE
MAIS-251 - Add "see unassigned conversations" permission to agent users

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -8,6 +8,10 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   after_action :check_assign_conversation, only: [:toggle_status]
 
   def index
+    if current_user.agent?
+      params[:team_id] = current_user.teams.pluck(:id)
+    end
+    
     result = conversation_finder.perform
     @conversations = result[:conversations]
     @conversations_count = result[:count]

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -374,8 +374,10 @@ export default {
       const ASSIGNEE_TYPE_TAB_KEYS = {
         me: 'mineCount',
         unassigned: 'unAssignedCount',
-        all: 'allCount',
+        
       };
+      if (this.currentUser.role !== 'agent') ASSIGNEE_TYPE_TAB_KEYS["all"] = 'allCount';
+
       return Object.keys(ASSIGNEE_TYPE_TAB_KEYS).map(key => {
         const count = this.conversationStats[ASSIGNEE_TYPE_TAB_KEYS[key]] || 0;
         return {

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -98,7 +98,7 @@
     />
 
     <chat-type-tabs
-      v-if="!hasAppliedFiltersOrActiveFolders && currentUser.role !== 'agent'"
+      v-if="!hasAppliedFiltersOrActiveFolders && seeTabsPermission"
       :items="assigneeTabItems"
       :active-tab="activeAssigneeTab"
       class="tab--chat-type"
@@ -361,6 +361,14 @@ export default {
         id,
         name,
       };
+    },
+    seeTabsPermission() {
+      if (this.currentUser.role !== 'agent') return true;
+
+      const currentAccount = this.currentUser.accounts.find((account) => account.id === this.currentUser.account_id);
+      const permission = currentAccount.permissions['see_unassigned_conversations'];
+      
+      return permission;
     },
     assigneeTabItems() {
       const ASSIGNEE_TYPE_TAB_KEYS = {

--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -128,7 +128,8 @@
         "LABELS": "View Labels",
         "CUSTOM_VIEWS": "View Custom Views",
         "PEOPLES": "View People",
-        "SEND_MESSAGES": "Send Messages"
+        "SEND_MESSAGES": "Send Messages",
+        "SEE_UNASSIGNED_CONVERSATIONS": "See Unassigned Conversations"
       }
     },
     "SEARCH": {

--- a/app/javascript/dashboard/i18n/locale/pt/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/pt/agentMgmt.json
@@ -127,7 +127,8 @@
         "LABELS": "Visualizar Etiquetas",
         "CUSTOM_VIEWS": "Visualizar Visualizações Personalizadas",
         "PEOPLES": "Visualizar Pessoais",
-        "SEND_MESSAGES": "Enviar Mensagens"
+        "SEND_MESSAGES": "Enviar Mensagens",
+        "SEE_UNASSIGNED_CONVERSATIONS": "Visualizar Conversas Não Atribuidas"
       }
     },
     "SEARCH": {

--- a/app/javascript/dashboard/i18n/locale/pt_BR/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/agentMgmt.json
@@ -127,7 +127,8 @@
         "LABELS": "Visualizar Etiquetas",
         "CUSTOM_VIEWS": "Visualizar Visualizações Personalizadas",
         "PEOPLES": "Visualizar Pessoais",
-        "SEND_MESSAGES": "Enviar Mensagens"
+        "SEND_MESSAGES": "Enviar Mensagens",
+        "SEE_UNASSIGNED_CONVERSATIONS": "Visualizar Conversas Não Atribuídas"
       }
     },
     "SEARCH": {

--- a/app/models/account_plan.rb
+++ b/app/models/account_plan.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: account_plans <- this is table is to link account and product and register the usage
+# Table name: account_plans
 #
 #  id                    :bigint           not null, primary key
 #  current_agents        :integer          default(0), not null

--- a/db/migrate/20241220173056_add_see_unassigned_conversations_to_account_users_permissions.rb
+++ b/db/migrate/20241220173056_add_see_unassigned_conversations_to_account_users_permissions.rb
@@ -1,0 +1,24 @@
+class AddSeeUnassignedConversationsToAccountUsersPermissions < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :account_users, :permissions, from: {
+      'conversations': true,
+      'reports': true,
+      'contacts': true,
+      'accounts': true,
+      'peoples': true,
+      'teams': true,
+      'labels': true,
+      'send_messages': true
+    }, to: {
+      'conversations': true,
+      'reports': true,
+      'contacts': true,
+      'accounts': true,
+      'peoples': true,
+      'teams': true,
+      'labels': true,
+      'send_messages': true,
+      'see_unassigned_conversations': true
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_04_180342) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_20_173056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_04_180342) do
     t.datetime "active_at", precision: nil
     t.integer "availability", default: 0, null: false
     t.boolean "auto_offline", default: true, null: false
-    t.jsonb "permissions", default: {"teams"=>true, "labels"=>true, "peoples"=>true, "reports"=>true, "accounts"=>true, "contacts"=>true, "conversations"=>true}
+    t.jsonb "permissions", default: {"teams"=>true, "labels"=>true, "peoples"=>true, "reports"=>true, "accounts"=>true, "contacts"=>true, "conversations"=>true, "send_messages"=>true, "see_unassigned_conversations"=>true}
     t.index ["account_id", "user_id"], name: "uniq_user_id_per_account_id", unique: true
     t.index ["account_id"], name: "index_account_users_on_account_id"
     t.index ["user_id"], name: "index_account_users_on_user_id"


### PR DESCRIPTION
This pull request include updating permissions to include a new `see_unassigned_conversations` permission.

### Updates to permissions:

* [`app/javascript/dashboard/components/ChatList.vue`](diffhunk://#diff-b5614c5cdc9eeb65a0625d2beb23bff694ad04410a416352ce3c3c3ea2972af4L101-R101): Added `seeTabsPermission` method to conditionally display chat type tabs based on the new `see_unassigned_conversations` permission. [[1]](diffhunk://#diff-b5614c5cdc9eeb65a0625d2beb23bff694ad04410a416352ce3c3c3ea2972af4L101-R101) [[2]](diffhunk://#diff-b5614c5cdc9eeb65a0625d2beb23bff694ad04410a416352ce3c3c3ea2972af4R365-R372)
* `app/javascript/dashboard/i18n/locale/en/agentMgmt.json`, `app/javascript/dashboard/i18n/locale/pt/agentMgmt.json`, `app/javascript/dashboard/i18n/locale/pt_BR/agentMgmt.json`: Updated translations to include `SEE_UNASSIGNED_CONVERSATIONS` permission. [[1]](diffhunk://#diff-006acf076764b18589a830e884aacda6d259de9a24c8c32475f96c4af4c58120L131-R132) [[2]](diffhunk://#diff-635adc08032e4a2ddf296f88e71ee56db726db6223cb754bcfbf6bc4f28303e4L130-R131) [[3]](diffhunk://#diff-d85d88e4b171b0374ac2f923ab68a0bce55434ed93ea72deb6b2fcf5d8e9bb80L130-R131)
* [`db/migrate/20241220173056_add_see_unassigned_conversations_to_account_users_permissions.rb`](diffhunk://#diff-bbb524b4059fc723d6471c49f5ca42170bed00c9212f8118e42241f1f958a367R1-R24): Added migration to include `see_unassigned_conversations` in default permissions.
* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13): Updated schema to reflect the new default permissions. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L65-R65)
