### PR TITLE
fix: update formatsToRemove and streamline message template filtering…

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
@@ -56,7 +56,7 @@
 
 <script>
 // TODO: Remove this when we support all formats
-const formatsToRemove = ['DOCUMENT', 'IMAGE', 'VIDEO'];
+const formatsToRemove = ['DOCUMENT', 'VIDEO'];
 
 export default {
   props: {

--- a/app/javascript/dashboard/i18n/locale/en/whatsappTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/en/whatsappTemplates.json
@@ -22,7 +22,10 @@
       "FORM_ERROR_MESSAGE": "Please fill all variables before sending",
       "BUTTONS_LABEL": "Buttons",
       "BUTTON_VARIABLES_LABEL": "Variables",
-      "BUTTON_TOOLTIP": "The button will be a link to the website, like this example: %{url}"
+      "BUTTON_TOOLTIP": "The button will be a link to the website, like this example: %{url}",
+      "HEADER_VARIABLES_LABEL": "Header Variables",
+      "IMAGE": "Image",
+      "VIDEO": "Video"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/pt/whatsappTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/pt/whatsappTemplates.json
@@ -22,7 +22,10 @@
       "FORM_ERROR_MESSAGE": "Preencha todas as variáveis antes de enviar",
       "BUTTONS_LABEL": "Botões",
       "BUTTON_VARIABLES_LABEL": "Variáveis",
-      "BUTTON_TOOLTIP": "O botão será um link para o site, como seguinte exemplo: %{url}"
+      "BUTTON_TOOLTIP": "O botão será um link para o site, como seguinte exemplo: %{url}",
+      "HEADER_VARIABLES_LABEL": "Variáveis do cabeçalho",
+      "IMAGE": "Imagem",
+      "VIDEO": "Vídeo"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/pt_BR/whatsappTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/whatsappTemplates.json
@@ -22,7 +22,10 @@
       "FORM_ERROR_MESSAGE": "Por favor, preencha todas as variáveis antes de enviar",
       "BUTTONS_LABEL": "Botões",
       "BUTTON_VARIABLES_LABEL": "Variáveis",
-      "BUTTON_TOOLTIP": "O botão será um link para o site, como seguinte exemplo: %{url}"
+      "BUTTON_TOOLTIP": "O botão será um link para o site, como seguinte exemplo: %{url}",
+      "HEADER_VARIABLES_LABEL": "Variáveis do cabeçalho",
+      "IMAGE": "Imagem",
+      "VIDEO": "Vídeo"
     }
   }
 }

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -67,9 +67,7 @@ export const getters = {
     // filtering out the whatsapp templates with media
     if (messagesTemplates instanceof Array) {
       return messagesTemplates.filter(template => {
-        return !template.components.some(
-          i => i.format === 'IMAGE' || i.format === 'VIDEO'
-        );
+        return !template.components.some(i => i.format === 'VIDEO');
       });
     }
     return [];

--- a/app/javascript/widget/helpers/linkHelper.js
+++ b/app/javascript/widget/helpers/linkHelper.js
@@ -1,0 +1,10 @@
+import { helpers } from 'vuelidate/lib/validators';
+
+/**
+ * Valida se o valor é uma URL válida.
+ * @type {Function}
+ */
+export const validUrl = helpers.regex(
+  'validUrl',
+  /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
+);

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -154,7 +154,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         policy: 'deterministic',
         code: template_info[:locale] || 'pt_BR'
       },
-      components: build_components(template_info)
+      components: build_components(template_info).concat(build_header_components(template_info[:headers]))
     }
   end
 
@@ -173,6 +173,24 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
       parameters: parameters.map do |param|
         { type: 'text', text: param[:text].presence || '' }
       end
+    }]
+  end
+
+  def build_header_components(headers)
+    return [] if headers.blank?
+    return [] if headers['type'].blank?
+
+    parameters = headers['values'].each_with_object([]) do |value, acc|
+      acc << {
+        :type => headers['type'].downcase,
+        headers['type'].downcase => { link: value }
+      }
+      acc
+    end
+
+    [{
+      type: 'header',
+      parameters: parameters
     }]
   end
 

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -15,7 +15,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   end
 
   def send_template_message
-    name, namespace, lang_code, processed_parameters, buttons = processable_channel_message_template
+    name, namespace, lang_code, processed_parameters, buttons, headers = processable_channel_message_template
     return if name.blank?
 
     message_id = channel.send_template(message.conversation.contact_inbox.source_id, {
@@ -23,7 +23,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          namespace: namespace,
                                          lang_code: lang_code,
                                          parameters: processed_parameters,
-                                         buttons: buttons
+                                         buttons: buttons,
+                                         headers: headers
                                        })
     message.update!(source_id: message_id) if message_id.present?
   end
@@ -38,7 +39,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
         template_params['processed_params']&.map { |_, value| { type: 'text', text: value } },
         template_params['buttons']&.map&.with_index do |button, index|
           { type: 'button', sub_type: button['type'], index: index, parameters: button['parameters'] }
-        end
+        end,
+        template_params['header']
       ]
     end
 
@@ -57,7 +59,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
       # no need to look up further end the search
       return [template['name'], template['namespace'], template['language'], processed_parameters]
     end
-    [nil, nil, nil, nil]
+    [nil, nil, nil, nil, nil]
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 


### PR DESCRIPTION
This pull request includes changes to the handling of WhatsApp templates in the dashboard component and store module. The main focus is on updating the formats that are filtered out.

Changes to WhatsApp templates handling:

* [`app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue`](diffhunk://#diff-9046cefa36c002009f6a21c7d9bc8b058b079363669bc0d51518b08eef8586aeL59-R59): Removed 'IMAGE' from the `formatsToRemove` array, now only 'DOCUMENT' and 'VIDEO' are excluded.
* [`app/javascript/dashboard/store/modules/inboxes.js`](diffhunk://#diff-a6e16253dc6782a634cd56a842392bc8c71c43cf6768ac91873b66774a8ee2deL70-R70): Updated the filtering logic to exclude only 'VIDEO' format from WhatsApp templates, no longer excluding 'IMAGE'.