### PR TITLE
Merge: Develop -> Main

### DIFF
--- a/app/views/api/v1/accounts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/index.json.jbuilder
@@ -7,7 +7,7 @@ json.data do
   end
   json.payload do
     json.array! @conversations do |conversation|
-      json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation, without_contact: true
+      json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
     end
   end
 end

--- a/app/views/api/v1/models/_contact.json.jbuilder
+++ b/app/views/api/v1/models/_contact.json.jbuilder
@@ -1,25 +1,25 @@
-json.additional_attributes resource.additional_attributes
-json.availability_status resource.availability_status
-json.email resource.email
-json.id resource.id
+json.additional_attributes resource&.additional_attributes || {}
+json.availability_status resource&.availability_status || 'offline'
+json.email resource&.email if resource&.email.present?
+json.id resource&.id if resource&.id.present?
 if defined?(conversation) && conversation.present?
   json.team_name conversation.team&.try(:name)
-  json.name "#{resource.name}##{conversation.tickets&.last&.id}"
+  json.name "#{resource&.name}##{conversation.tickets&.last&.id}"
 else
-  json.name resource.name
+  json.name resource&.name
 end
 
-json.phone_number resource.phone_number
-json.identifier resource.identifier
-json.thumbnail resource.avatar_url
-json.custom_attributes resource.custom_attributes
-json.last_activity_at resource.last_activity_at.to_i if resource[:last_activity_at].present?
-json.created_at resource.created_at.to_i if resource[:created_at].present?
+json.phone_number resource&.phone_number if resource&.phone_number.present?
+json.identifier resource&.identifier if resource&.identifier.present?
+json.thumbnail resource&.avatar_url if resource&.avatar_url.present?
+json.custom_attributes resource&.custom_attributes || {}
+json.last_activity_at resource&.last_activity_at.to_i if resource&.try(:last_activity_at).present?
+json.created_at resource&.created_at.to_i if resource&.try(:created_at).present?
 
 # we only want to output contact inbox when its /contacts endpoints
 if defined?(with_contact_inboxes) && with_contact_inboxes.present?
   json.contact_inboxes do
-    json.array! resource.contact_inboxes do |contact_inbox|
+    json.array! resource&.contact_inboxes do |contact_inbox|
       json.partial! 'api/v1/models/contact_inbox', formats: [:json], resource: contact_inbox
     end
   end


### PR DESCRIPTION
This pull request introduces several changes to the `app/services/whatsapp/providers/whatsapp_cloud_service.rb` file to enhance the handling of WhatsApp message templates. The key modifications include adding a method to retrieve a template by name, updating the template body parameters, and improving the way components and body components are built.

Enhancements to template handling:

* Added `get_template` method to retrieve a template by its name.
* Updated `send_template` method to use the retrieved template in the request payload.
* Modified `template_body_parameters` method to accept the template as a parameter and updated the components accordingly.
* Enhanced `build_components` and `build_body_component` methods to utilize the template and include parameter names in the body components.

New methods for template component retrieval:

* Added `get_template_body` and `get_template_params_name_body` methods to extract body components and parameter names from the template.