### PR TITLE
Mais 295/add conversation

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -139,8 +139,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     @message = Messages::MessageBuilder.new(
       current_user,
       @conversation,
-      content: permitted_params_message[:message][:content],
-      message_type: :incoming
+      content: permitted_params_message[:message][:content]
     ).perform
   end
 

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -181,6 +181,7 @@
 
     <modal-create-new-conversation
       :show="showCreateNewConversationModal"
+      :selected-inbox="conversationInbox"
       @cancel="showCreateNewConversationModal = false"
     />
   </div>

--- a/app/javascript/dashboard/modules/search/components/ModalCreateNewConversation.vue
+++ b/app/javascript/dashboard/modules/search/components/ModalCreateNewConversation.vue
@@ -219,6 +219,7 @@ export default {
       currentUser: 'getCurrentUser',
       currentAccount: 'getCurrentAccount',
       inboxes: 'inboxes/getInboxes',
+      activeInbox: 'getSelectedInbox',
     }),
     isFormValid() {
       return !this.$v.$invalid;
@@ -238,6 +239,11 @@ export default {
 
       return '';
     },
+  },
+  mounted() {
+    if (this.activeInbox) {
+      this.setSelectedInbox(this.activeInbox);
+    }
   },
   methods: {
     async onSubmit() {
@@ -339,6 +345,12 @@ export default {
       this.$v.contactName.$touch();
       this.$v.conversationEmail.$touch();
       this.$v.phoneNumber.$touch();
+    },
+    setSelectedInbox(inboxId) {
+      const inbox = this.inboxes.find(i => i.id === String(inboxId));
+      if (inbox) {
+        this.selectedInbox = inbox;
+      }
     },
   },
 };


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to both the backend and frontend codebases. The most important changes involve refactoring methods in the `ContactsController` and updating the `ModalCreateNewConversation` component in the frontend.

Backend Refactoring:

* [`app/controllers/api/v1/accounts/contacts_controller.rb`](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21L93-R94): Refactored the `contact_and_message` method by extracting the logic into two new private methods, `find_or_create_contact` and `create_conversation_and_message`, to improve code readability and maintainability. [[1]](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21L93-R94) [[2]](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21R123-R145)

Frontend Updates:

* [`app/javascript/dashboard/components/ChatList.vue`](diffhunk://#diff-b5614c5cdc9eeb65a0625d2beb23bff694ad04410a416352ce3c3c3ea2972af4R184): Added a new prop `selected-inbox` to the `modal-create-new-conversation` component to pass the selected inbox.
* [`app/javascript/dashboard/modules/search/components/ModalCreateNewConversation.vue`](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429L92-R95): Refactored the component to replace `selectedInbox` with `inbox` for better clarity and added a watcher to handle changes to the `selectedInbox` prop. This includes updates to the data model, validation, and the `onSubmit` method to use the new `inbox` property. [[1]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429L92-R95) [[2]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429L128-R129) [[3]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429R192-R195) [[4]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429R205-L202) [[5]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429L215-R221) [[6]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429R248-R258) [[7]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429L258-R285) [[8]](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429R364-R376)