### PR TITLE
Mais 275/add permit telegram group

### DIFF
--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -19,7 +19,7 @@ class ContactInboxBuilder
       wa_source_id
     when 'Channel::Email'
       email_source_id
-    when 'Channel::Sms'
+    when 'Channel::Sms', 'Channel::Telegram'
       phone_source_id
     when 'Channel::Api', 'Channel::WebWidget'
       SecureRandom.uuid

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -131,8 +131,15 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def create_conversation_and_message
+    params_message = permitted_params_message
+    if @contact_inbox.inbox.telegram?
+      params_message[:additional_attributes] = {
+        chat_id: find_chat_id
+      }
+    end
+
     @conversation = ConversationBuilder.new(
-      params: permitted_params_message,
+      params: params_message,
       contact_inbox: @contact_inbox
     ).perform
 
@@ -228,5 +235,9 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def only_numbers(string)
     "+#{string.gsub(/[^\d]/, '')}"
+  end
+
+  def find_chat_id
+    @contact_inbox.inbox.channel.find_chat_id
   end
 end

--- a/app/models/channel/telegram.rb
+++ b/app/models/channel/telegram.rb
@@ -56,6 +56,21 @@ class Channel::Telegram < ApplicationRecord
     "https://api.telegram.org/file/bot#{bot_token}/#{response.parsed_response['result']['file_path']}"
   end
 
+  def find_chat_id
+    response = HTTParty.get("#{telegram_api_url}/getUpdates")
+    return unless response.success?
+
+    updates = response.parsed_response['result'] || []
+
+    update_with_chat = updates.find do |update|
+      update.dig('message', 'chat', 'id') || update.dig('edited_message', 'chat', 'id')
+    end
+
+    return unless update_with_chat
+
+    update_with_chat.dig('message', 'chat', 'id') || update_with_chat.dig('edited_message', 'chat', 'id')
+  end
+
   private
 
   def ensure_valid_bot_token

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -125,6 +125,10 @@ class Inbox < ApplicationRecord
     channel_type == 'Channel::Whatsapp'
   end
 
+  def telegram?
+    channel_type == 'Channel::Telegram'
+  end
+
   def assignable_agents
     (account.users.where(id: members.select(:user_id)) + account.administrators).uniq
   end

--- a/app/services/telegram/incoming_message_service.rb
+++ b/app/services/telegram/incoming_message_service.rb
@@ -71,9 +71,17 @@ class Telegram::IncomingMessageService
 
   def contact_attributes
     {
-      name: "#{telegram_params_first_name} #{telegram_params_last_name}",
+      name: telegram_params_chat_name,
       additional_attributes: additional_attributes
     }
+  end
+
+  def telegram_params_chat_name
+    if telegram_params_chat_type == 'private'
+      "#{telegram_params_first_name} #{telegram_params_last_name}"
+    else
+      telegram_params_chat_title
+    end
   end
 
   def additional_attributes
@@ -85,7 +93,9 @@ class Telegram::IncomingMessageService
 
   def conversation_additional_attributes
     {
-      chat_id: telegram_params_chat_id
+      chat_id: telegram_params_chat_id,
+      chat_title: telegram_params_chat_title,
+      chat_type: telegram_params_chat_type
     }
   end
 
@@ -136,5 +146,13 @@ class Telegram::IncomingMessageService
 
   def visual_media_params
     params[:message][:photo].presence&.last || params.dig(:message, :sticker, :thumb).presence || params[:message][:video].presence
+  end
+
+  def telegram_params_chat_title
+    telegram_params_base_object[:chat][:title]
+  end
+
+  def telegram_params_chat_type
+    telegram_params_base_object[:chat][:type]
   end
 end

--- a/app/services/telegram/param_helpers.rb
+++ b/app/services/telegram/param_helpers.rb
@@ -3,7 +3,8 @@ module Telegram::ParamHelpers
   def private_message?
     return true if callback_query_params?
 
-    params.dig(:message, :chat, :type) == 'private'
+    chat_type = params.dig(:message, :chat, :type)
+    %w[private group supergroup].include?(chat_type)
   end
 
   def telegram_params_content_attributes


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality and integration of Telegram channels within the application. The key modifications include adding support for Telegram in various parts of the codebase and improving the handling of Telegram-specific attributes.

Enhancements for Telegram support:

* [`app/builders/contact_inbox_builder.rb`](diffhunk://#diff-d66798e70e56db1d8853fa28093c501f53fe08648f250cbdd0d704f4c738ad73L22-R22): Added support for 'Channel::Telegram' in the `generate_source_id` method to use `phone_source_id`.
* [`app/controllers/api/v1/accounts/contacts_controller.rb`](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21R134-R142): Modified the `create_conversation_and_message` method to include Telegram-specific attributes and added a new `find_chat_id` method. [[1]](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21R134-R142) [[2]](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21R239-R242)
* [`app/models/channel/telegram.rb`](diffhunk://#diff-e14301440e62db46c97db8328abc0d8c6d6e9bd54e81a980b4f2b861efadde36R59-R73): Added a `find_chat_id` method to retrieve the chat ID from Telegram updates.
* [`app/models/inbox.rb`](diffhunk://#diff-69e4611c7f780a5d098030bf9bb105687a5a9d550461d954ac985b4d08c12e38R128-R131): Introduced a new `telegram?` method to check if the channel type is 'Channel::Telegram'.

Handling Telegram-specific attributes:

* [`app/services/telegram/incoming_message_service.rb`](diffhunk://#diff-4fbdd7fbfb88fc1622ae6eee6ea42178c208f9c00d2d5508edfcbaba8ac8c31aL74-R86): Updated methods to handle Telegram chat names, titles, and types, including `contact_attributes`, `telegram_params_chat_name`, and `conversation_additional_attributes`. [[1]](diffhunk://#diff-4fbdd7fbfb88fc1622ae6eee6ea42178c208f9c00d2d5508edfcbaba8ac8c31aL74-R86) [[2]](diffhunk://#diff-4fbdd7fbfb88fc1622ae6eee6ea42178c208f9c00d2d5508edfcbaba8ac8c31aL88-R98) [[3]](diffhunk://#diff-4fbdd7fbfb88fc1622ae6eee6ea42178c208f9c00d2d5508edfcbaba8ac8c31aR150-R157)
* [`app/services/telegram/param_helpers.rb`](diffhunk://#diff-0ebd96138ed1304f50786ef5bacfb20b16d15c53ae3c084eb26edc8c25c9231dL6-R7): Enhanced the `private_message?` method to include 'group' and 'supergroup' chat types.