### PR TITLE
MAIS-298 - Formatted message instead of fixed botMessage for CSAT at conversation

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -263,6 +263,16 @@ export default {
         }
       );
 
+      if (this.contentType === 'input_csat' && this.data?.content) {
+        return (
+          this.formatMessage(
+            this.data.content,
+            this.isATweet,
+            this.data.private
+          )
+        );
+      }
+
       if (this.contentType === 'input_csat') {
         return this.$t('CONVERSATION.CSAT_REPLY_MESSAGE') + botMessageContent;
       }


### PR DESCRIPTION
This pull request introduces a fix to csat messages content.

### Changes:
Verify if there is a message content before using csat default message at `widgets/conversation/Message.vue`.