### PR TITLE
Merge: develop -> Main

### DIFF
--- a/app/dispatchers/async_dispatcher.rb
+++ b/app/dispatchers/async_dispatcher.rb
@@ -17,8 +17,7 @@ class AsyncDispatcher < BaseDispatcher
       NotificationListener.instance,
       ReportingEventListener.instance,
       WebhookListener.instance,
-      AutomationRuleListener.instance,
-      WhatsappListener.instance
+      AutomationRuleListener.instance
     ]
   end
 end

--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -196,6 +196,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    channelType: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -288,7 +292,9 @@ export default {
     contextMenuEnabledOptions() {
       return {
         copy: this.hasText,
-        delete: this.hasText || this.hasAttachments,
+        delete:
+          (this.hasText || this.hasAttachments) &&
+          this.channelType !== 'Channel::Whatsapp',
         cannedResponse: this.isOutgoing && this.hasText,
         replyTo:
           !this.data.private &&

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -51,6 +51,7 @@
         :is-a-tweet="isATweet"
         :is-a-whatsapp-channel="isAWhatsAppChannel"
         :is-web-widget-inbox="isAWebWidgetInbox"
+        :channel-type="inbox.channel_type"
         :inbox-supports-reply-to="inboxSupportsReplyTo"
         :in-reply-to="getInReplyToMessage(message)"
       />
@@ -73,6 +74,7 @@
         :is-a-tweet="isATweet"
         :is-a-whatsapp-channel="isAWhatsAppChannel"
         :is-web-widget-inbox="isAWebWidgetInbox"
+        :channel-type="inbox.channel_type"
         :inbox-supports-reply-to="inboxSupportsReplyTo"
         :in-reply-to="getInReplyToMessage(message)"
       />


### PR DESCRIPTION
This pull request includes changes to the `QRCodeWhatsapp.vue` file to temporarily comment out certain sections of the HTML code. These changes likely aim to hide specific elements in the user interface without permanently removing them.

The most important changes include:

* Commented out the `div` containing the `useReopenConversation` input element.
* Commented out the `div` containing the `useConversationPending` input element. [[1]](diffhunk://#diff-227cb2afa3a1c87044fdd5b2f266674f16be66bacf1ad9edc0f7b77fed86801dL62-R64) [[2]](diffhunk://#diff-227cb2afa3a1c87044fdd5b2f266674f16be66bacf1ad9edc0f7b77fed86801dL74-R74)