### PR TITLE
Mais 326/add phone number format

### DIFF
--- a/app/helpers/phone_helper.rb
+++ b/app/helpers/phone_helper.rb
@@ -2,10 +2,57 @@ module PhoneHelper
   def format_phone_number(phone_number)
     return phone_number if phone_number.blank?
 
-    phone_number.gsub!(/[^\d]/, '')
-    phone_number = "55#{phone_number}" if !phone_number.start_with?('55') && (phone_number.length == 10 || phone_number.length == 11)
-    phone_number = "+#{phone_number}" unless phone_number.start_with?('+')
-
     phone_number
+      .then { |n| clean_number(n) }
+      .then { |n| ensure_country_code(n) }
+      .then { |n| ensure_plus_prefix(n) }
+      .then { |n| ensure_nine_digit(n) }
+  end
+
+  private
+
+  def clean_number(number)
+    number.gsub(/[^\d]/, '')
+  end
+
+  def ensure_country_code(number)
+    return "55#{number}" if !number.start_with?('55') && [10, 11].include?(number.length)
+
+    number
+  end
+
+  def ensure_plus_prefix(number)
+    number.start_with?('+') ? number : "+#{number}"
+  end
+
+  def ensure_nine_digit(number)
+    return number unless number.start_with?('+55')
+
+    digits = number[1..]
+    ddd, subscriber = extract_ddd_and_subscriber(digits)
+
+    return number unless needs_nine_digit?(subscriber)
+
+    insert_nine_digit(number, ddd)
+  end
+
+  def extract_ddd_and_subscriber(digits)
+    case digits.length
+    when 10
+      [digits[0, 2], digits[2..]]
+    when 12
+      [digits[2, 2], digits[4..]]
+    else
+      [nil, nil]
+    end
+  end
+
+  def needs_nine_digit?(subscriber)
+    subscriber && subscriber.length == 8 && subscriber[0].match?(/[6-9]/)
+  end
+
+  def insert_nine_digit(number, ddd)
+    position = ddd ? number.index(ddd) + 2 : 3
+    number.insert(position, '9')
   end
 end


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the `format_phone_number` method in the `PhoneHelper` module. The changes aim to make the code more modular, readable, and maintainable by breaking down the logic into smaller helper methods.

Refactoring and improvements:

* [`app/helpers/phone_helper.rb`](diffhunk://#diff-c27ebb425ce1908c8ad91a204ebacf4a0dc9bf12e7904d3eac857de6fcf857bfL5-R56): Refactored the `format_phone_number` method to use a series of helper methods (`clean_number`, `ensure_country_code`, `ensure_plus_prefix`, and `ensure_nine_digit`) for better readability and maintainability.
* [`app/helpers/phone_helper.rb`](diffhunk://#diff-c27ebb425ce1908c8ad91a204ebacf4a0dc9bf12e7904d3eac857de6fcf857bfL5-R56): Added private helper methods `clean_number`, `ensure_country_code`, `ensure_plus_prefix`, `ensure_nine_digit`, `extract_ddd_and_subscriber`, `needs_nine_digit?`, and `insert_nine_digit` to encapsulate specific pieces of logic.