### PR TITLE
feat: enhance agent assignment with team association and improve agen…

### DIFF
--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -10,7 +10,8 @@ class AutoAssignment::AgentAssignmentService
 
   def perform
     new_assignee = find_assignee
-    conversation.update(assignee: new_assignee) if new_assignee
+
+    conversation.update(assignee: new_assignee, team: find_team(new_assignee)) if new_assignee
   end
 
   private
@@ -34,5 +35,9 @@ class AutoAssignment::AgentAssignmentService
 
   def round_robin_key
     format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
+  end
+
+  def find_team(assignee)
+    assignee.teams.order(:level).first
   end
 end

--- a/app/services/auto_assignment/inbox_round_robin_service.rb
+++ b/app/services/auto_assignment/inbox_round_robin_service.rb
@@ -27,6 +27,7 @@ class AutoAssignment::InboxRoundRobinService
   # the values of allowed member ids should be in string format
   def available_agent(allowed_agent_ids: [])
     reset_queue unless validate_queue?
+
     user_id = get_member_from_allowed_agent_ids_hierarchical(allowed_agent_ids)
     inbox.inbox_members.find_by(user_id: user_id)&.user if user_id.present?
   end
@@ -49,7 +50,7 @@ class AutoAssignment::InboxRoundRobinService
     while current_level <= max_hierarchy_level
       level_agent_ids = agents_by_level(current_level, allowed_agent_ids)
       user_id = level_agent_ids.intersection(queue).pop
-      return pop_push_to_queue(user_id) if user_id.present?
+      return pop_push_to_queue(user_id) && user_id if user_id.present?
 
       current_level += 1
     end


### PR DESCRIPTION
This pull request includes several changes to the `app/services/auto_assignment` directory, focusing on improving the agent assignment and round-robin management services. The most important changes include updating the `perform` method to also set the team, adding a new method to find the team of an assignee, and refining the logic for retrieving and updating user IDs.

Improvements to agent assignment:

* [`app/services/auto_assignment/agent_assignment_service.rb`](diffhunk://#diff-9113ec9e7864d20d62d93768de3640d4063e2c30aa4d1e48384e3607ca53ea5cL13-R14): Modified the `perform` method to update the conversation with both the new assignee and their team.
* [`app/services/auto_assignment/agent_assignment_service.rb`](diffhunk://#diff-9113ec9e7864d20d62d93768de3640d4063e2c30aa4d1e48384e3607ca53ea5cR39-R42): Added a new `find_team` method to determine the team of an assignee based on their level.

Enhancements to round-robin management:

* [`app/services/auto_assignment/inbox_round_robin_service.rb`](diffhunk://#diff-58f12789d3c5098a56283f43b3ccea7cb9102257f24162af6bf9b89c877c356fR30): Added a line break in the `available_agent` method for better readability.
* [`app/services/auto_assignment/inbox_round_robin_service.rb`](diffhunk://#diff-58f12789d3c5098a56283f43b3ccea7cb9102257f24162af6bf9b89c877c356fL52-R53): Updated the `get_member_from_allowed_agent_ids_hierarchical` method to return the user ID after popping and pushing it to the queue.