### PR TITLE
feat: add support for creating new conversations with type parameter

### DIFF
--- a/app/builders/conversation_builder.rb
+++ b/app/builders/conversation_builder.rb
@@ -15,6 +15,8 @@ class ConversationBuilder
   private
 
   def look_up_existing_conversation
+    return if params[:type] == 'create_new_conversation'
+
     return unless @contact_inbox.inbox.lock_to_single_conversation?
 
     @contact_inbox.conversations.last

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -139,7 +139,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     end
 
     if permitted_params[:assign_current_user]
-      params_message[:team_id] = current_user.team_ids.first
+      params_message[:team_id] = current_user.teams.where(account: current_account).first
       params_message[:assignee_id] = current_user.id
     end
 
@@ -196,7 +196,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def permitted_params_message
-    params.permit(:inbox_id, :contact_id, contact: {}, message: {})
+    params.permit(:inbox_id, :contact_id, :type, contact: {}, message: {})
   end
 
   def contact_custom_attributes

--- a/app/javascript/dashboard/api/contacts.js
+++ b/app/javascript/dashboard/api/contacts.js
@@ -97,12 +97,19 @@ class ContactAPI extends ApiClient {
     );
   }
 
-  createContactAndMessage({ contact, message, inboxId, assignCurrentUser }) {
+  createContactAndMessage({
+    contact,
+    message,
+    inboxId,
+    assignCurrentUser,
+    type,
+  }) {
     return axios.post(`${this.url}/messages`, {
       contact,
       message,
       inbox_id: inboxId,
       assign_current_user: assignCurrentUser,
+      type,
     });
   }
 }

--- a/app/javascript/dashboard/modules/search/components/ModalCreateNewConversation.vue
+++ b/app/javascript/dashboard/modules/search/components/ModalCreateNewConversation.vue
@@ -283,6 +283,7 @@ export default {
           message: this.conversationMessage,
           inboxId: this.inbox.id,
           assignCurrentUser: this.assignCurrentUser,
+          type: 'create_new_conversation',
         };
 
         const response = await ContactsAPI.createContactAndMessage(payload);


### PR DESCRIPTION
This pull request introduces changes to support the creation of new conversations and updates the assignment of team IDs based on the current account. The most important changes include modifications to the `perform` method in `conversation_builder.rb`, updates to the `create_conversation_and_message` and `permitted_params` methods in `contacts_controller.rb`, and adjustments to the `createContactAndMessage` method in `contacts.js`.

### Support for creating new conversations:

* [`app/builders/conversation_builder.rb`](diffhunk://#diff-e20983485402ca35be6f23f3dcf9b468cf184e1527e47e661d9d234c9e53f737R18-R19): Added a condition to return early if the `params[:type]` is `'create_new_conversation'` in the `perform` method.

* [`app/controllers/api/v1/accounts/contacts_controller.rb`](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21L199-R199): Updated the `permitted_params_message` method to include the `:type` parameter.

* [`app/javascript/dashboard/api/contacts.js`](diffhunk://#diff-bbdcab6f88945cb316a17d4b6d306da48d802866dbed452a59bb2735bc71f422L100-R112): Modified the `createContactAndMessage` method to accept and include the `type` parameter in the API request.

* [`app/javascript/dashboard/modules/search/components/ModalCreateNewConversation.vue`](diffhunk://#diff-82ee22d686394adcf5fa76b515131b7dc845ddcea72fa22279c7ff7cb066d429R286): Added the `type` parameter with the value `'create_new_conversation'` to the payload in the `createContactAndMessage` call.

### Assignment of team IDs:

* [`app/controllers/api/v1/accounts/contacts_controller.rb`](diffhunk://#diff-9c3ceeb825474ffa043601be1af67d83b15daf068a33b2edec2cbadc28c36b21L142-R142): Changed the assignment of `params_message[:team_id]` to select the first team where the account matches the current account.